### PR TITLE
Landing page dashboard selected tabs

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -27,6 +27,12 @@ export const externalLinkIcon = {
   alt: 'External link icon',
 };
 
+// --------------- Tabs Index Mapping --------------
+export const tabIndexMap = {
+  'participants': 0,
+  'samples': 1,
+  'files': 2,
+};
 
 // --------------- Tabs Header Data configuration --------------
 export const tabs = [

--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -39,12 +39,12 @@ export const landingPageData = {
     {
       statTitle: 'samples',
       statAPI: 'numberOfSamples',
-      callToActionLink: '/data',
+      callToActionLink: '/data?selectedTab=samples',
     },
     {
       statTitle: 'files',
       statAPI: 'numberOfFiles',
-      callToActionLink: '/data',
+      callToActionLink: '/data?selectedTab=files',
     },
   ],
   tile1: {

--- a/src/pages/dashTemplate/DashTemplateController.js
+++ b/src/pages/dashTemplate/DashTemplateController.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { connect } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { CircularProgress } from '@material-ui/core';
 import { getFilters } from '@bento-core/facet-filter';
 import DashTemplateView from './DashTemplateView';
@@ -12,6 +13,15 @@ const getDashData = (states) => {
     localFindUpload, localFindAutocomplete,
   } = states;
 
+  const tabIndexMap = {
+    'participants': 0,
+    'samples': 1,
+    'files': 2,
+  };
+  const { search } = useLocation();
+  const tabName = search ? new URLSearchParams(search).get('selectedTab').toLowerCase() : 'participants';
+  const tabIndex = tabIndexMap[tabName];
+  
   const client = useApolloClient();
   async function getData(activeFilters) {
     const result = await client.query({
@@ -41,11 +51,11 @@ const getDashData = (states) => {
     });
     return () => controller.abort();
   }, [filterState, localFindUpload, localFindAutocomplete]);
-  return { dashData, activeFilters };
+  return { dashData, activeFilters, tabIndex };
 };
 
 const DashTemplateController = ((props) => {
-  const { dashData, activeFilters } = getDashData(props);
+  const { dashData, activeFilters, tabIndex } = getDashData(props);
 
   if (!dashData) {
     return (<CircularProgress />);
@@ -56,6 +66,7 @@ const DashTemplateController = ((props) => {
       {...props}
       dashData={dashData}
       activeFilters={activeFilters}
+      tabIndex={tabIndex}
     />
   );
 });

--- a/src/pages/dashTemplate/DashTemplateController.js
+++ b/src/pages/dashTemplate/DashTemplateController.js
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { CircularProgress } from '@material-ui/core';
 import { getFilters } from '@bento-core/facet-filter';
 import DashTemplateView from './DashTemplateView';
-import { DASHBOARD_QUERY } from '../../bento/dashboardTabData';
+import { DASHBOARD_QUERY, tabIndexMap } from '../../bento/dashboardTabData';
 
 const getDashData = (states) => {
   const {
@@ -13,11 +13,6 @@ const getDashData = (states) => {
     localFindUpload, localFindAutocomplete,
   } = states;
 
-  const tabIndexMap = {
-    'participants': 0,
-    'samples': 1,
-    'files': 2,
-  };
   const { search } = useLocation();
   const tabName = search ? new URLSearchParams(search).get('selectedTab').toLowerCase() : 'participants';
   const tabIndex = tabIndexMap[tabName];

--- a/src/pages/dashTemplate/DashTemplateView.js
+++ b/src/pages/dashTemplate/DashTemplateView.js
@@ -11,7 +11,8 @@ const DashTemplate = ({
   classes,
   dashData,
   activeFilters,
-}) => (
+  tabIndex,
+}) => ( 
   <div className={classes.dashboardContainer}>
     <StatsView data={dashData} />
     <div>
@@ -31,6 +32,7 @@ const DashTemplate = ({
             <TabsView
               dashboardStats={dashData}
               activeFilters={activeFilters}
+              tabIndex={tabIndex}
             />
           </div>
         </div>

--- a/src/pages/dashTemplate/tabs/TabsView.js
+++ b/src/pages/dashTemplate/tabs/TabsView.js
@@ -5,7 +5,7 @@ import { Tabs as BentoTabs }  from '@bento-core/tab';
 import { customTheme } from './DefaultTabTheme';
 
 const Tabs = (props) => {
-  const [currentTab, setCurrentTab] = useState(0);
+  const [currentTab, setCurrentTab] = useState(props.tabIndex || 0);
   const handleTabChange = (event, value) => {
     setCurrentTab(value);
   };


### PR DESCRIPTION
When clicking on the statsbar on the landing page, the user will be redirected to the dashboard on their selected stat (participants, samples, files) any bad parameters will result in the default tab of 0

ended up props drilling down from dashcontroller to dashview to tabsview