### PR TITLE
enabled downloading of table metadata from the data page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@bento-core/about": "^1.0.1-CDS.1",
         "@bento-core/all": "^1.0.0",
         "@bento-core/nav-bar": "^1.0.1-CDS.0",
+        "@bento-core/paginated-table": "^1.0.1-icdc.11",
         "@bento-core/stats-bar": "^1.0.1-CDS.0",
         "@jbrowse/react-linear-genome-view": "^2.1.5",
         "@librpc/web": "^1.1.1",
@@ -1477,6 +1478,25 @@
         "react-router-dom": "^5.1.2"
       }
     },
+    "node_modules/@bento-core/all/node_modules/@bento-core/paginated-table": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.0.tgz",
+      "integrity": "sha512-BG8KM8VBI7RNs+w7XnPSHgdOiZeDtu7p44An9K00743kN/P3xuPcMJWdE2xHyKX1KtJBqZo3mbEi9pdflg1hXA==",
+      "dependencies": {
+        "@bento-core/cart": "^1.0.0",
+        "@bento-core/table": "^1.0.0",
+        "@bento-core/tool-tip": "^1.0.0",
+        "@bento-core/util": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^3.6.9",
+        "@material-ui/core": "^4.12.4",
+        "clsx": "^1.2.1",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.0",
+        "react-redux": "^7.2.1"
+      }
+    },
     "node_modules/@bento-core/all/node_modules/@bento-core/stats-bar": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@bento-core/stats-bar/-/stats-bar-1.0.0.tgz",
@@ -1659,12 +1679,12 @@
       }
     },
     "node_modules/@bento-core/paginated-table": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.0.tgz",
-      "integrity": "sha512-BG8KM8VBI7RNs+w7XnPSHgdOiZeDtu7p44An9K00743kN/P3xuPcMJWdE2xHyKX1KtJBqZo3mbEi9pdflg1hXA==",
+      "version": "1.0.1-icdc.11",
+      "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.1-icdc.11.tgz",
+      "integrity": "sha512-1IV9p+bJ9/Ygf1koSuVj3XEjEaAaqF9tkyFk3Pk5rq+5DKvzOty+w7C110lRFzEswJy1HVl6R2SzvqQfDt/7CA==",
       "dependencies": {
         "@bento-core/cart": "^1.0.0",
-        "@bento-core/table": "^1.0.0",
+        "@bento-core/table": "1.0.1-icdc.2",
         "@bento-core/tool-tip": "^1.0.0",
         "@bento-core/util": "^1.0.0"
       },
@@ -1672,6 +1692,24 @@
         "@apollo/client": "^3.6.9",
         "@material-ui/core": "^4.12.4",
         "clsx": "^1.2.1",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.0",
+        "react-redux": "^7.2.1"
+      }
+    },
+    "node_modules/@bento-core/paginated-table/node_modules/@bento-core/table": {
+      "version": "1.0.1-icdc.2",
+      "resolved": "https://registry.npmjs.org/@bento-core/table/-/table-1.0.1-icdc.2.tgz",
+      "integrity": "sha512-wDRI4591JmbxIdUFrfdCr5gaCbvAP6WtXpBnZSYdDeNJw0E3qPtqV6zOi0ffY2elS/wvxKAUln23rHFXgohVIw==",
+      "dependencies": {
+        "@bento-core/util": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^3.6.9",
+        "@material-ui/core": "^4.12.4",
+        "@material-ui/icons": "^4.9.1",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.0",
         "react-redux": "^7.2.1"
@@ -1692,6 +1730,25 @@
         "react-dom": "^17.0.0",
         "react-redux": "^7.2.1",
         "react-router-dom": "^5.1.2"
+      }
+    },
+    "node_modules/@bento-core/profile/node_modules/@bento-core/paginated-table": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.0.tgz",
+      "integrity": "sha512-BG8KM8VBI7RNs+w7XnPSHgdOiZeDtu7p44An9K00743kN/P3xuPcMJWdE2xHyKX1KtJBqZo3mbEi9pdflg1hXA==",
+      "dependencies": {
+        "@bento-core/cart": "^1.0.0",
+        "@bento-core/table": "^1.0.0",
+        "@bento-core/tool-tip": "^1.0.0",
+        "@bento-core/util": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^3.6.9",
+        "@material-ui/core": "^4.12.4",
+        "clsx": "^1.2.1",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.0",
+        "react-redux": "^7.2.1"
       }
     },
     "node_modules/@bento-core/query-bar": {
@@ -26029,6 +26086,17 @@
             "prop-types": "^15.7.2"
           }
         },
+        "@bento-core/paginated-table": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.0.tgz",
+          "integrity": "sha512-BG8KM8VBI7RNs+w7XnPSHgdOiZeDtu7p44An9K00743kN/P3xuPcMJWdE2xHyKX1KtJBqZo3mbEi9pdflg1hXA==",
+          "requires": {
+            "@bento-core/cart": "^1.0.0",
+            "@bento-core/table": "^1.0.0",
+            "@bento-core/tool-tip": "^1.0.0",
+            "@bento-core/util": "^1.0.0"
+          }
+        },
         "@bento-core/stats-bar": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@bento-core/stats-bar/-/stats-bar-1.0.0.tgz",
@@ -26139,14 +26207,24 @@
       }
     },
     "@bento-core/paginated-table": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.0.tgz",
-      "integrity": "sha512-BG8KM8VBI7RNs+w7XnPSHgdOiZeDtu7p44An9K00743kN/P3xuPcMJWdE2xHyKX1KtJBqZo3mbEi9pdflg1hXA==",
+      "version": "1.0.1-icdc.11",
+      "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.1-icdc.11.tgz",
+      "integrity": "sha512-1IV9p+bJ9/Ygf1koSuVj3XEjEaAaqF9tkyFk3Pk5rq+5DKvzOty+w7C110lRFzEswJy1HVl6R2SzvqQfDt/7CA==",
       "requires": {
         "@bento-core/cart": "^1.0.0",
-        "@bento-core/table": "^1.0.0",
+        "@bento-core/table": "1.0.1-icdc.2",
         "@bento-core/tool-tip": "^1.0.0",
         "@bento-core/util": "^1.0.0"
+      },
+      "dependencies": {
+        "@bento-core/table": {
+          "version": "1.0.1-icdc.2",
+          "resolved": "https://registry.npmjs.org/@bento-core/table/-/table-1.0.1-icdc.2.tgz",
+          "integrity": "sha512-wDRI4591JmbxIdUFrfdCr5gaCbvAP6WtXpBnZSYdDeNJw0E3qPtqV6zOi0ffY2elS/wvxKAUln23rHFXgohVIw==",
+          "requires": {
+            "@bento-core/util": "^1.0.0"
+          }
+        }
       }
     },
     "@bento-core/profile": {
@@ -26156,6 +26234,19 @@
       "requires": {
         "@bento-core/paginated-table": "^1.0.0",
         "@bento-core/util": "^1.0.0"
+      },
+      "dependencies": {
+        "@bento-core/paginated-table": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@bento-core/paginated-table/-/paginated-table-1.0.0.tgz",
+          "integrity": "sha512-BG8KM8VBI7RNs+w7XnPSHgdOiZeDtu7p44An9K00743kN/P3xuPcMJWdE2xHyKX1KtJBqZo3mbEi9pdflg1hXA==",
+          "requires": {
+            "@bento-core/cart": "^1.0.0",
+            "@bento-core/table": "^1.0.0",
+            "@bento-core/tool-tip": "^1.0.0",
+            "@bento-core/util": "^1.0.0"
+          }
+        }
       }
     },
     "@bento-core/query-bar": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@bento-core/about": "^1.0.1-CDS.1",
     "@bento-core/all": "^1.0.0",
     "@bento-core/nav-bar": "^1.0.1-CDS.0",
+    "@bento-core/paginated-table": "^1.0.1-icdc.11",
     "@bento-core/stats-bar": "^1.0.1-CDS.0",
     "@jbrowse/react-linear-genome-view": "^2.1.5",
     "@librpc/web": "^1.1.1",

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -751,6 +751,10 @@ export const tabContainers = [
     extendedViewConfig: {
       pagination: true,
       manageViewColumns: true,
+      download: {
+        downloadCsv: 'Download Table Content As CSV',
+        downloadFileName: 'CDS_participant_Download',
+      },
     },
     columns: [
       {
@@ -826,7 +830,10 @@ export const tabContainers = [
     extendedViewConfig: {
       pagination: true,
       manageViewColumns: true,
-      // download: true,
+      download: {
+        downloadCsv: 'Download Table Content As CSV',
+        downloadFileName: 'CDS_sample_Download',
+      },
     },
     saveButtonDefaultStyle: {
       color: '#fff',
@@ -924,6 +931,10 @@ export const tabContainers = [
     extendedViewConfig: {
       pagination: true,
       manageViewColumns: true,
+      download: {
+        downloadCsv: 'Download Table Content As CSV',
+        downloadFileName: 'CDS_file_Download',
+      },
     },
     columns: [
       {


### PR DESCRIPTION
pulled package from ICDC

tables now have metadata download:
- filter the table with facets and download the entire table's metadata.
- will have the date in its name
- is in csv format