### PR TITLE
email now links to email direct

### DIFF
--- a/src/content/dev/aboutPagesContent.yaml
+++ b/src/content/dev/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."

--- a/src/content/dev2/aboutPagesContent.yaml
+++ b/src/content/dev2/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."

--- a/src/content/local/aboutPagesContent.yaml
+++ b/src/content/local/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."

--- a/src/content/perf/aboutPagesContent.yaml
+++ b/src/content/perf/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."

--- a/src/content/prod/aboutPagesContent.yaml
+++ b/src/content/prod/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."

--- a/src/content/qa/aboutPagesContent.yaml
+++ b/src/content/qa/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."

--- a/src/content/qa2/aboutPagesContent.yaml
+++ b/src/content/qa2/aboutPagesContent.yaml
@@ -77,4 +77,4 @@
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/about/support.jpeg'
   content: 
     - 
-      paragraph: "If you have any questions, please contact us at $$@cdshelpdesk@mail.nih.gov@$$."
+      paragraph: "If you have any questions, please contact us at $$[CDSHelpDesk@mail.nih.gov](CDSHelpDesk@mail.nih.gov)$$."


### PR DESCRIPTION
Updated the about pages to treat the support email as a hyperlink to redirect to the email.