### PR TITLE
CDS-774 Adobe Launch Government Shutdown Banner 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,11 @@
   <script src="./js/session.js"></script>
   <script src="./injectEnv.js"></script>
 
+  <!-- 
+    Government Shutdown banner
+    -->
+  <script src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js" async></script>
+
   <!--
       Change line below to update title for the application.
       Ideal Length: <= 33 Characters.

--- a/src/bento/globalStatsData.js
+++ b/src/bento/globalStatsData.js
@@ -6,7 +6,7 @@ export const statsStyling = {
     statTitleFirst: false,
     height: '58px',
     background: '#B4E2F5',
-    top: 'calc(var(--alert-margin-top) + 139px)',
+    top: 'calc(var(--site-alert-offset) + 139px)',
   },
   statsGroup: {
     margin: '6px 0px',

--- a/src/bento/globalStatsData.js
+++ b/src/bento/globalStatsData.js
@@ -6,6 +6,7 @@ export const statsStyling = {
     statTitleFirst: false,
     height: '58px',
     background: '#B4E2F5',
+    top: 'calc(var(--alert-margin-top) + 139px)',
   },
   statsGroup: {
     margin: '6px 0px',

--- a/src/bento/navigationBarData.js
+++ b/src/bento/navigationBarData.js
@@ -6,6 +6,7 @@ export const navBarstyling = {
     fontColor: '#bbefff',
     activeLabel: '1px solid #bbefff',
     textTransform: 'capitalize',
+    marginTop: 'calc(var(--alert-margin-top) + 100px)'
   },
   dropDownIcon: {
     displayIcon: false,

--- a/src/bento/navigationBarData.js
+++ b/src/bento/navigationBarData.js
@@ -6,7 +6,7 @@ export const navBarstyling = {
     fontColor: '#bbefff',
     activeLabel: '1px solid #bbefff',
     textTransform: 'capitalize',
-    marginTop: 'calc(var(--alert-margin-top) + 100px)'
+    marginTop: 'calc(var(--site-alert-offset) + 100px)'
   },
   dropDownIcon: {
     displayIcon: false,

--- a/src/components/Header/HeaderView.js
+++ b/src/components/Header/HeaderView.js
@@ -10,7 +10,7 @@ import { accessLevelTypes } from '@bento-core/authentication';
 
 const customStyle = {
   headerBar: {
-    marginTop: 'var(--alert-margin-top)',
+    marginTop: 'var(--site-alert-offset)',
   },
   nihLogoImg: {
     width: '463px',

--- a/src/components/Header/HeaderView.js
+++ b/src/components/Header/HeaderView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import  {Header}  from '@bento-core/header';
 import { withRouter } from 'react-router-dom';
@@ -22,6 +22,14 @@ const customStyle = {
 
 const ICDCHeader = (props) => {
   const { location } = props;
+  const withPageOffsetStyle = {
+    headerBar: {
+      marginTop: "var(--alert-margin-top)",
+    },
+  }
+  const styles = useMemo(() => {
+    return { ...customStyle, ...withPageOffsetStyle };
+  }, [customStyle, withPageOffsetStyle])
 
   const isSignedIn = useSelector((state) => state && state.login.isSignedIn);
   const isAdmin = useSelector((state) => state.login && state.login.role && state.login.role === 'admin');
@@ -46,7 +54,7 @@ const ICDCHeader = (props) => {
       alt={headerData.globalHeaderLogoAltText}
       homeLink={headerData.globalHeaderLogoLink}
       SearchComponent={!location.pathname.match('/search') ? SearchBar : undefined}
-      customStyle={customStyle}
+      customStyle={styles}
     />
   );
 };

--- a/src/components/Header/HeaderView.js
+++ b/src/components/Header/HeaderView.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import  {Header}  from '@bento-core/header';
 import { withRouter } from 'react-router-dom';
@@ -9,6 +9,9 @@ import { PUBLIC_ACCESS } from '../../bento/siteWideConfig';
 import { accessLevelTypes } from '@bento-core/authentication';
 
 const customStyle = {
+  headerBar: {
+    marginTop: 'var(--alert-margin-top)',
+  },
   nihLogoImg: {
     width: '463px',
     height: '54px',
@@ -22,14 +25,6 @@ const customStyle = {
 
 const ICDCHeader = (props) => {
   const { location } = props;
-  const withPageOffsetStyle = {
-    headerBar: {
-      marginTop: "var(--alert-margin-top)",
-    },
-  }
-  const styles = useMemo(() => {
-    return { ...customStyle, ...withPageOffsetStyle };
-  }, [customStyle, withPageOffsetStyle])
 
   const isSignedIn = useSelector((state) => state && state.login.isSignedIn);
   const isAdmin = useSelector((state) => state.login && state.login.role && state.login.role === 'admin');
@@ -54,7 +49,7 @@ const ICDCHeader = (props) => {
       alt={headerData.globalHeaderLogoAltText}
       homeLink={headerData.globalHeaderLogoLink}
       SearchComponent={!location.pathname.match('/search') ? SearchBar : undefined}
-      customStyle={styles}
+      customStyle={customStyle}
     />
   );
 };

--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -53,13 +53,13 @@ const Layout = ({ classes, isSidebarOpened }) => {
     const adjustForSiteAlert = () => {
       const hostDiv = document.body.children[0];
       if (!hostDiv || !hostDiv.shadowRoot) {
-        document.documentElement.style.setProperty('--alert-margin-top', '0px');
+        document.documentElement.style.setProperty('--site-alert-offset', '0px');
         return;
       }
 
       const siteAlert = hostDiv.shadowRoot.querySelector('.usa-site-alert');
       if (siteAlert) {
-        document.documentElement.style.setProperty('--alert-margin-top', `${siteAlert.offsetHeight}px`);
+        document.documentElement.style.setProperty('--site-alert-offset', `${siteAlert.offsetHeight}px`);
 
         // Adjust site alert styling to also be fixed
         siteAlert.style.position = 'fixed';
@@ -179,7 +179,7 @@ const styles = (theme) => ({
     // width: `calc(100vw - 240px)`,   // Ajay need to add this on addung side bar
     width: 'calc(100%)', // Remove this on adding sidebar
     background: theme.custom.bodyBackGround,
-    marginTop: 'calc(var(--alert-margin-top) + 196px)',
+    marginTop: 'calc(var(--site-alert-offset) + 196px)',
   },
   '@global': {
     '*::-webkit-scrollbar': {

--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -55,7 +55,6 @@ const Layout = ({ classes, isSidebarOpened }) => {
       if (hostDiv && hostDiv.shadowRoot) {
         const siteAlert = hostDiv.shadowRoot.querySelector('.usa-site-alert');
         if (siteAlert) {
-          console.log(siteAlert.offsetHeight);
           document.documentElement.style.setProperty('--alert-margin-top', `${siteAlert.offsetHeight}px`);
 
           // Adjust site alert styling to also be fixed

--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { withStyles, CssBaseline } from '@material-ui/core';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import aboutPageRoutes from '../../bento/aboutPagesRoutes';
@@ -49,6 +49,42 @@ const Layout = ({ classes, isSidebarOpened }) => {
   // Access control imports
   const { LoginRoute, MixedRoute, PrivateRoute, AdminRoute} = AuthenticationMiddlewareGenerator(AUTH_MIDDLEWARE_CONFIG);
 
+  useEffect(() => {
+    const adjustForSiteAlert = () => {
+      const hostDiv = document.body.children[0];
+      if (hostDiv && hostDiv.shadowRoot) {
+        const siteAlert = hostDiv.shadowRoot.querySelector('.usa-site-alert');
+        if (siteAlert) {
+          console.log(siteAlert.offsetHeight);
+          document.documentElement.style.setProperty('--alert-margin-top', `${siteAlert.offsetHeight}px`);
+
+          // Adjust site alert styling to also be fixed
+          siteAlert.style.position = "fixed";
+          siteAlert.style.top = 0;
+          siteAlert.style.left = 0;
+          siteAlert.style.width = "100%";
+          siteAlert.style.zIndex = "9999";
+        }
+      } else {
+        document.documentElement.style.setProperty('--alert-margin-top', '0px');
+      }
+    };
+
+    // Initial check
+    adjustForSiteAlert();
+    const observer = new MutationObserver(adjustForSiteAlert);
+
+    observer.observe(document.body, {
+      childList: true,
+    });
+    window.addEventListener('resize', adjustForSiteAlert);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', adjustForSiteAlert);
+    }
+  }, [])
+    
   return (
   <>
     <CssBaseline />
@@ -143,7 +179,7 @@ const styles = (theme) => ({
     // width: `calc(100vw - 240px)`,   // Ajay need to add this on addung side bar
     width: 'calc(100%)', // Remove this on adding sidebar
     background: theme.custom.bodyBackGround,
-    marginTop: '196px',
+    marginTop: 'calc(var(--alert-margin-top) + 196px)',
   },
   '@global': {
     '*::-webkit-scrollbar': {

--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -52,20 +52,21 @@ const Layout = ({ classes, isSidebarOpened }) => {
   useEffect(() => {
     const adjustForSiteAlert = () => {
       const hostDiv = document.body.children[0];
-      if (hostDiv && hostDiv.shadowRoot) {
-        const siteAlert = hostDiv.shadowRoot.querySelector('.usa-site-alert');
-        if (siteAlert) {
-          document.documentElement.style.setProperty('--alert-margin-top', `${siteAlert.offsetHeight}px`);
-
-          // Adjust site alert styling to also be fixed
-          siteAlert.style.position = "fixed";
-          siteAlert.style.top = 0;
-          siteAlert.style.left = 0;
-          siteAlert.style.width = "100%";
-          siteAlert.style.zIndex = "9999";
-        }
-      } else {
+      if (!hostDiv || !hostDiv.shadowRoot) {
         document.documentElement.style.setProperty('--alert-margin-top', '0px');
+        return;
+      }
+
+      const siteAlert = hostDiv.shadowRoot.querySelector('.usa-site-alert');
+      if (siteAlert) {
+        document.documentElement.style.setProperty('--alert-margin-top', `${siteAlert.offsetHeight}px`);
+
+        // Adjust site alert styling to also be fixed
+        siteAlert.style.position = 'fixed';
+        siteAlert.style.top = 0;
+        siteAlert.style.left = 0;
+        siteAlert.style.width = '100%';
+        siteAlert.style.zIndex = '9999';
       }
     };
 

--- a/src/components/NavBar/NavBarView.js
+++ b/src/components/NavBar/NavBarView.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { NavBar } from '@bento-core/nav-bar';
 import {
@@ -11,15 +11,6 @@ import { accessLevelTypes } from '@bento-core/authentication';
 const BentoNavBar = ({ cartFieldIds = [] }) => {
   const isSignedIn = useSelector((state) => state.login.isSignedIn);
   const { METADATA_ONLY } = accessLevelTypes;
-  const withPageOffsetStyle = {
-    global: {
-      ...navBarstyling.global,
-      marginTop: "calc(var(--alert-margin-top) + 100px)"
-    }
-  };
-  const styles = useMemo(() => {
-    return { ...navBarstyling, ...withPageOffsetStyle };
-  }, [navBarstyling, withPageOffsetStyle])
 
   const getNumberOfCase = () => {
     const { length: numberOfCases } = cartFieldIds;
@@ -39,7 +30,7 @@ const BentoNavBar = ({ cartFieldIds = [] }) => {
       <NavBar
         navBarData={navBarData}
         navBarCartData={navBarCartData}
-        navBarstyling={styles}
+        navBarstyling={navBarstyling}
         numberOfCases={getNumberOfCase()}
         LoginComponent={getLoginComponent()}
       />

--- a/src/components/NavBar/NavBarView.js
+++ b/src/components/NavBar/NavBarView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { NavBar } from '@bento-core/nav-bar';
 import {
@@ -11,6 +11,16 @@ import { accessLevelTypes } from '@bento-core/authentication';
 const BentoNavBar = ({ cartFieldIds = [] }) => {
   const isSignedIn = useSelector((state) => state.login.isSignedIn);
   const { METADATA_ONLY } = accessLevelTypes;
+  const withPageOffsetStyle = {
+    global: {
+      ...navBarstyling.global,
+      marginTop: "calc(var(--alert-margin-top) + 100px)"
+    }
+  };
+  const styles = useMemo(() => {
+    return { ...navBarstyling, ...withPageOffsetStyle };
+  }, [navBarstyling, withPageOffsetStyle])
+  console.log({ styles });
 
   const getNumberOfCase = () => {
     const { length: numberOfCases } = cartFieldIds;
@@ -30,7 +40,7 @@ const BentoNavBar = ({ cartFieldIds = [] }) => {
       <NavBar
         navBarData={navBarData}
         navBarCartData={navBarCartData}
-        navBarstyling={navBarstyling}
+        navBarstyling={styles}
         numberOfCases={getNumberOfCase()}
         LoginComponent={getLoginComponent()}
       />

--- a/src/components/NavBar/NavBarView.js
+++ b/src/components/NavBar/NavBarView.js
@@ -20,7 +20,6 @@ const BentoNavBar = ({ cartFieldIds = [] }) => {
   const styles = useMemo(() => {
     return { ...navBarstyling, ...withPageOffsetStyle };
   }, [navBarstyling, withPageOffsetStyle])
-  console.log({ styles });
 
   const getNumberOfCase = () => {
     const { length: numberOfCases } = cartFieldIds;


### PR DESCRIPTION
### Overview

Added the Adobe Launch Government Shutdown banner script to the head of the site. Had to adjust styling since it is a Bento project with a fixed header and navigation.

### Change Details (Specifics)

Since Bento projects use a fixed header and navigation, it required some adjustments. Added MutationObserver and resize listener to check for the injected government shutdown banner. If it exists it will set a global CSS variable, in which fixed elements will use to offset themselves under the banner.

### Related Ticket(s)

[CDS-774](https://tracker.nci.nih.gov/browse/CDS-774)