### PR TITLE
CDS-811 Update logo for lower tiers

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -3,7 +3,7 @@ import Easter from '../assets/header/headerGraphic.png';
 // globalHeaderLogo image 468x100
 // globalHeaderImage: image 2200x100
 export default {
-  globalHeaderLogo: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/logo/cds-logo.svg',
+  globalHeaderLogo: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/cds/logo/dh-logo.svg',
   globalHeaderLogoLink: '/',
   globalHeaderLogoAltText: 'CDS Logo',
   globalHeaderImage: Easter,


### PR DESCRIPTION
### Overview

Updated logo for lower tiers to match DataHub branding.

### Change Details (Specifics)

Asset updated in PR https://github.com/CBIIT/datacommons-assets/pull/79

> [!NOTE]
> The datacommons-assets PR should be merged first

### Related Ticket(s)

[CDS-811](https://tracker.nci.nih.gov/browse/CDS-811)