### PR TITLE
CDS-892 Cart table and downloaded manifest spelling fix

### DIFF
--- a/src/bento/fileCentricCartWorkflowData.js
+++ b/src/bento/fileCentricCartWorkflowData.js
@@ -113,7 +113,7 @@ export const myFilesPageData = {
 
 export const manifestData = {
   keysToInclude: ['file_id', 'file_name', 'subject_id', 'md5sum', 'associated_file', 'associated_drs_uri', 'associated_md5sum', 'study_acronym', 'phs_accession', 'sample_id', 'accesses', 'file_type', 'gender', 'race', 'primary_diagnosis', 'is_tumor', 'analyte_type', 'organ_or_tissue', 'study_data_type', 'library_strategy', 'image_modality', 'experimental_strategy', 'library_layouts', 'license', 'file_size'],
-  header: ['drs_uri', 'name', 'Participant ID', 'Md5sum', 'Associated File', 'Associated File DRS URI', 'Associated File md5sum', 'Study Name', 'Accession', 'Sample Id', 'Study Access', 'File Type', 'Gender', 'Race', 'Primary Diagnosis', 'Sample Tumor Status', 'Analyte Type', 'Organ or Tissue', 'Study Data Type', 'Library Strategy', ' Image Modality', 'Experimental Strategy', 'Library Layouts', 'License', 'File Size (in bytes)', 'User Comments'],
+  header: ['drs_uri', 'name', 'Participant ID', 'Md5sum', 'Associated File', 'Associated File DRS URI', 'Associated File md5sum', 'Study Name', 'Accession', 'Sample Id', 'Study Access', 'File Type', 'Gender', 'Race', 'Primary Diagnosis', 'Sample Tumor Status', 'Analyte Type', 'Organ or Tissue', 'Study Data Type', 'Library Strategy', ' Image Modality', 'Experimental Strategy', 'Library Layout', 'License', 'File Size (in bytes)', 'User Comments'],
 };
 
 // --------------- GraphQL query - Retrieve selected cases info --------------
@@ -326,7 +326,7 @@ export const table = {
     },
     {
       dataField: 'library_layouts',
-      header: 'Library Layouts',
+      header: 'Library Layout',
       display: false,
       tooltipText: 'sort',
       role: cellTypes.DISPLAY,


### PR DESCRIPTION
### Overview

Updated "Library Layouts" property header in the cart Table filter/column, as well as in the downloaded Manifest file, to "Library Layout" instead.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CDS-892](https://tracker.nci.nih.gov/browse/CDS-892)