### PR TITLE
Library Strategy is now shown by default

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -1165,7 +1165,7 @@ export const tabContainers = [
       {
         dataField: 'library_strategy',
         header: 'Library Strategy',
-        display: false,
+        display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
         cellType: cellTypes.CUSTOM_ELEM,


### PR DESCRIPTION
Requirement from

[CDS-947](https://tracker.nci.nih.gov/browse/CDS-947). 