### PR TITLE
Cds 962 - Fixed footer email link

### DIFF
--- a/src/bento/globalFooterData.js
+++ b/src/bento/globalFooterData.js
@@ -18,7 +18,7 @@ export default {
       items: [
         {
           text: 'CDRC Help Desk',
-          link: 'NCICRDC@mail.nih.gov',
+          link: 'mailto:NCICRDC@mail.nih.gov',
         },
       ],
     },


### PR DESCRIPTION
[CDS-962](https://tracker.nci.nih.gov/browse/CDS-962)

Was missing the prefix to make it an email link