### PR TITLE
CDS-992 Remove redundant tooltip icon on Data Explore page

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -5,6 +5,19 @@ import { customCasesTabDownloadCSV, customFilesTabDownloadCSV, customSamplesTabD
 import { dataFormatTypes } from '@bento-core/table';
 import { STATIC_CONTENT } from '../assets/staticContent';
 
+// --------------- Tooltip configuration --------------
+export const addAllFilesButtonTooltipConfig = {
+  title: 'Click to add all files associated with the study.',
+  arrow: true,
+  placement: 'top',
+};
+
+export const addSelectedFilesButtonTooltipConfig = {
+  title: 'Click to add only the files you have selected associated with the participants or samples.',
+  arrow: true,
+  placement: 'top',
+};
+
 // --------------- Dahboard Table external link configuration --------------
 // Ideal size for externalLinkIcon is 16x16 px
 export const externalLinkIcon = {
@@ -969,20 +982,6 @@ export const tabContainers = [
         cellType: cellTypes.CUSTOM_ELEM,
       },
       {
-        dataField: 'is_tumor',
-        header: 'Tumor',
-        display: true,
-        tooltipText: 'sort',
-        role: cellTypes.DISPLAY,
-      },
-      {
-        dataField: 'analyte_type',
-        header: 'Analyte Type',
-        display: true,
-        tooltipText: 'sort',
-        role: cellTypes.DISPLAY,
-      },
-      {
         dataField: 'files',
         header: 'Files',
         display: false,
@@ -1194,5 +1193,6 @@ export const tabContainers = [
     //addSelectedFilesQuery: GET_ALL_FILEIDS_FILESTAB_FOR_SELECT_ALL,
   },
 ];
+
 
   

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -5,22 +5,6 @@ import { customCasesTabDownloadCSV, customFilesTabDownloadCSV, customSamplesTabD
 import { dataFormatTypes } from '@bento-core/table';
 import { STATIC_CONTENT } from '../assets/staticContent';
 
-// --------------- Tooltip configuration --------------
-export const tooltipContent = {
-  icon: 'https://raw.githubusercontent.com/google/material-design-icons/master/src/action/help/materialicons/24px.svg',
-  alt: 'tooltipIcon',
-  0: 'Click button to add selected files associated with the selected case(s).',
-  1: 'Click button to add selected files associated with the selected sample(s).',
-  2: 'Click button to add selected files.',
-  Participants: 'Select to add participant files.',
-  Samples: 'Select to add sample files.',
-  Files: 'Select to add files.',
-  arrow: true,
-  styles: {
-    border: '#03A383 1px solid',
-  }
-};
-
 // --------------- Dahboard Table external link configuration --------------
 // Ideal size for externalLinkIcon is 16x16 px
 export const externalLinkIcon = {

--- a/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
+++ b/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
@@ -66,6 +66,11 @@ export const wrapperConfig = [{
       role: btnTypes.ADD_SELECTED_FILES,
       btnType: btnTypes.ADD_SELECTED_FILES,
       conditional: true,
+      buttonTooltipConfig: {
+        title: "Click to add only the files you have selected associated with the participants or samples.",
+        arrow: true,
+        placement: "top"
+      },
     }],
 },
 {

--- a/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
+++ b/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
@@ -2,6 +2,10 @@ import {
   btnTypes,
   types,
 } from '@bento-core/paginated-table';
+import {
+  addAllFilesButtonTooltipConfig,
+  addSelectedFilesButtonTooltipConfig,
+} from '../../../../bento/dashboardTabData';
 import { alertMessage } from '../../../../bento/fileCentricCartWorkflowData';
 
 export const layoutConfig = [{
@@ -29,11 +33,7 @@ export const wrapperConfig = [{
       btnType: btnTypes.ADD_ALL_FILES,
       conditional: false,
       alertMessage,
-      buttonTooltipConfig: {
-        title: "Click to add all files associated with the study.",
-        arrow: true,
-        placement: "top",
-      },
+      buttonTooltipConfig: addAllFilesButtonTooltipConfig,
     },
     {
       title: 'ADD SELECTED FILES',
@@ -43,11 +43,7 @@ export const wrapperConfig = [{
       btnType: btnTypes.ADD_SELECTED_FILES,
       conditional: true,
       alertMessage,
-      buttonTooltipConfig: {
-        title: "Click to add only the files you have selected associated with the participants or samples.",
-        arrow: true,
-        placement: "top"
-      },
+      buttonTooltipConfig: addSelectedFilesButtonTooltipConfig,
     }],
 },
 {
@@ -66,11 +62,7 @@ export const wrapperConfig = [{
       role: btnTypes.ADD_SELECTED_FILES,
       btnType: btnTypes.ADD_SELECTED_FILES,
       conditional: true,
-      buttonTooltipConfig: {
-        title: "Click to add only the files you have selected associated with the participants or samples.",
-        arrow: true,
-        placement: "top"
-      },
+      buttonTooltipConfig: addSelectedFilesButtonTooltipConfig,
     }],
 },
 {

--- a/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
+++ b/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
@@ -2,9 +2,6 @@ import {
   btnTypes,
   types,
 } from '@bento-core/paginated-table';
-import {
-  tooltipContent,
-} from '../../../../bento/dashboardTabData';
 import { alertMessage } from '../../../../bento/fileCentricCartWorkflowData';
 
 export const layoutConfig = [{
@@ -44,7 +41,6 @@ export const wrapperConfig = [{
       type: types.BUTTON,
       role: btnTypes.ADD_SELECTED_FILES,
       btnType: btnTypes.ADD_SELECTED_FILES,
-      tooltipCofig: tooltipContent,
       conditional: true,
       alertMessage,
       buttonTooltipConfig: {
@@ -69,7 +65,6 @@ export const wrapperConfig = [{
       type: types.BUTTON,
       role: btnTypes.ADD_SELECTED_FILES,
       btnType: btnTypes.ADD_SELECTED_FILES,
-      tooltipCofig: tooltipContent,
       conditional: true,
     }],
 },


### PR DESCRIPTION
### Overview

Removed redundant tooltip "?" icon in the Data Explore page for the "Add Selected Files" button. This was replaced with a hover tooltip on the button directly.

### Change Details (Specifics)

- Removed icon tooltip for "Add Selected Files" button
- Added missing button tooltip for the "Add Selected Files" button below the table.

### Related Ticket(s)

[CDS-992](https://tracker.nci.nih.gov/browse/CDS-992)