### PR TITLE
Cards in Global Search now have link-outs

### DIFF
--- a/src/bento/search.js
+++ b/src/bento/search.js
@@ -200,6 +200,7 @@ query globalSearch($input: String, $first: Int, $offset: Int){
         subjects {
             type
             subject_id
+            subject_ids_filter
             study
             site
         }
@@ -219,6 +220,7 @@ query globalSearch($input: String, $first: Int, $offset: Int){
             sample_id
             is_tumor
             analyte_type
+            subject_ids_filter
         }
 }
 }
@@ -238,6 +240,7 @@ query globalSearch($input: String, $first: Int, $offset: Int){
             file_id
             file_name
             file_type
+            subject_ids_filter
         }
 }
 }

--- a/src/pages/search/cards/CaseCard.js
+++ b/src/pages/search/cards/CaseCard.js
@@ -1,7 +1,9 @@
-import { Grid, withStyles } from '@material-ui/core';
 import React from 'react';
+import { Grid, withStyles } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 import { prepareLinks } from '@bento-core/util';
 import PropertyItem from './PropertyItem';
+import { encodeSubjectIds } from './utils';
 
 const CARD_PROPERTIES = [
   {
@@ -10,7 +12,7 @@ const CARD_PROPERTIES = [
   },
   {
     label: 'Study',
-      dataField: 'study',
+    dataField: 'study',
   },
 ];
 
@@ -26,7 +28,9 @@ const CaseCard = ({ data, classes, index }) => {
         <div>
           <span className={classes.detailContainerHeader}>PARTICIPANT</span>
           <span className={classes.cardTitle}>
-            {data.subject_id}
+            <Link to={`/data/${encodeSubjectIds(data['subject_ids_filter'])}`} className={classes.cardTitle}>
+              {data.subject_id}
+            </Link>
           </span>
         </div>
         {propertiesWithLinks.map((prop, idx) => (

--- a/src/pages/search/cards/FileCard.js
+++ b/src/pages/search/cards/FileCard.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Grid, withStyles } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 import { prepareLinks } from '@bento-core/util';
 import PropertyItem from './PropertyItem';
+import { encodeSubjectIds } from './utils';
 
 const CARD_PROPERTIES = [
   {
@@ -42,7 +44,9 @@ const FileCard = ({ data, classes, index }) => {
         <div>
           <span className={classes.detailContainerHeader}>FILE</span>
           <span className={classes.cardTitle}>
-            {data.file_id}
+            <Link to={`/data/${encodeSubjectIds(data['subject_ids_filter'])}`} className={classes.cardTitle}>
+              {data.file_id}
+            </Link>
           </span>
         </div>
         {propertiesWithLinks.map((prop, idx) => (

--- a/src/pages/search/cards/SampleCard.js
+++ b/src/pages/search/cards/SampleCard.js
@@ -1,7 +1,9 @@
-import { Grid, withStyles } from '@material-ui/core';
 import React from 'react';
+import { Grid, withStyles } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 import { prepareLinks } from '@bento-core/util';
 import PropertyItem from './PropertyItem';
+import { encodeSubjectIds } from './utils';
 
 const CARD_PROPERTIES = [
   {
@@ -30,7 +32,9 @@ const SampleCard = ({ data, classes, index }) => {
         <div>
           <span className={classes.detailContainerHeader}>Sample</span>
           <span className={classes.cardTitle}>
+            <Link to={`/data/${encodeSubjectIds(data['subject_ids_filter'])}`} className={classes.cardTitle}>
               {data.sample_id}
+            </Link>
           </span>
         </div>
         {propertiesWithLinks.map((prop, idx) => (

--- a/src/pages/search/cards/StudyCard.js
+++ b/src/pages/search/cards/StudyCard.js
@@ -60,7 +60,7 @@ const styles = (theme) => ({
   cardTitle: {
     color: theme.palette.text.link,
     textDecoration: 'none',
-    fontSize: '40px',
+    fontSize: '16px',
     fontFamily: 'Nunito',
     paddingLeft: '9px',
     verticalAlign: 'middle',

--- a/src/pages/search/cards/StudyCard.js
+++ b/src/pages/search/cards/StudyCard.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Grid, withStyles } from '@material-ui/core';
-import { Link } from 'react-router-dom';
 import { prepareLinks } from '@bento-core/util';
 import PropertyItem from './PropertyItem';
 
@@ -8,6 +7,7 @@ const CARD_PROPERTIES = [
   {
     label: 'Study Name',
     dataField: 'study_name',
+    link: '/study/{phs_accession}',
   },
   {
     label: 'Study Code',
@@ -31,9 +31,6 @@ const StudyCard = ({ data, classes, index }) => {
         <div>
           <span className={classes.detailContainerHeader}>STUDY</span>
           <span className={classes.cardTitle}>
-            <Link to={`/arm/${data.study_code}`} className={classes.cardTitle}>
-              {data.study_id}
-            </Link>
           </span>
         </div>
         {propertiesWithLinks.map((prop, idx) => (
@@ -63,7 +60,7 @@ const styles = (theme) => ({
   cardTitle: {
     color: theme.palette.text.link,
     textDecoration: 'none',
-    fontSize: '16px',
+    fontSize: '40px',
     fontFamily: 'Nunito',
     paddingLeft: '9px',
     verticalAlign: 'middle',

--- a/src/pages/search/cards/utils.js
+++ b/src/pages/search/cards/utils.js
@@ -1,0 +1,10 @@
+export function encodeSubjectIds(subjectIdsArray) {
+  const autocompleteArray = subjectIdsArray.map((subjectId) => {
+    return {
+      "type": "subjectIds",
+      "title": subjectId,
+    }
+  });
+  
+  return encodeURIComponent(JSON.stringify({"autocomplete": autocompleteArray}));
+}


### PR DESCRIPTION
[CDS-1017](https://tracker.nci.nih.gov/browse/CDS-1017) 

For the Participant, Study, Sample, and FIle cards in global search, they link out to either the explore page with the respective filters or their personal page in the case of the Study card.

This is done through the new query variable and a util function formatting it for the URL decoder 