### PR TITLE
CDS-1131 Study Details table - Fix Sample ID value wrapping

### DIFF
--- a/src/bento/dashboard.js
+++ b/src/bento/dashboard.js
@@ -7,7 +7,7 @@ const SEQUENCING = 'Sequencing';
 const IMAGING = 'Imaging';
 const DIAGNOSIS = 'Diagnosis';
 const FILES = 'Files';
-const PROTEOMIC = 'Proteomic';
+// const PROTEOMIC = 'Proteomic';
 
 // --------------- Facet resetIcon link configuration --------------
 // Ideal size for resetIcon is 16x16 px

--- a/src/pages/studyDetail/tableConfig/Theme.js
+++ b/src/pages/studyDetail/tableConfig/Theme.js
@@ -130,6 +130,9 @@ export const tblBody = {
           fontWeight: 'bold',
         },
       },
+      '&.sample_id': {
+        maxWidth: '160px',
+      }
     },
     root: {
       minHeight: '45px',


### PR DESCRIPTION
### Overview

The Sample ID table column in the Study Details page was breaking in undesired spots. I updated its max-width so that it properly breaks at word instead of force breaking due to overflow. This is caused by long names with no spaces.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CDS-1131](https://tracker.nci.nih.gov/browse/CDS-1131)