### PR TITLE
CDS-1129 Fix 1k File Limit alert message for footer button 

### DIFF
--- a/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
+++ b/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
@@ -62,6 +62,7 @@ export const wrapperConfig = [{
       role: btnTypes.ADD_SELECTED_FILES,
       btnType: btnTypes.ADD_SELECTED_FILES,
       conditional: true,
+      alertMessage,
       buttonTooltipConfig: addSelectedFilesButtonTooltipConfig,
     }],
 },


### PR DESCRIPTION
### Overview

The 1k file limit alert message was missing for the "Add Selected Files" button under the table. It was simply missing from the config, so I went ahead and added it there.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CDS-1129](https://tracker.nci.nih.gov/browse/CDS-1129)