### PR TITLE
updated new header components to go to '/home' instead of '/'

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -6,7 +6,7 @@ import { STATIC_CONTENT } from '../assets/staticContent';
 export const headerData = {
   globalHeaderLogo: STATIC_CONTENT.logo.CRDC_LOGO_SVG,
   globalHeaderLogoSmall: STATIC_CONTENT.logo.CRDC_LOGO_SVG,
-  globalHeaderLogoLink: '/',
+  globalHeaderLogoLink: '/home',
   globalHeaderLogoAltText: 'Portal Logo',
   usaFlagSmall,
   usaFlagSmallAltText: 'usaFlagSmall',
@@ -15,7 +15,7 @@ export const headerData = {
 export const HeaderLinks = [
   {
     name: 'Home',
-    link: '/',
+    link: '/home',
     id: 'navbar-dropdown-home',
     className: 'navMobileItem',
   },


### PR DESCRIPTION
[CDS-1257](https://tracker.nci.nih.gov/browse/CDS-1257)

This is due to us moving to a new header which had the configuration remove the 'home' suffix