### PR TITLE
CDS-1259 Hide extra clear button from global search page searchbox

### DIFF
--- a/src/pages/search/styles.js
+++ b/src/pages/search/styles.js
@@ -112,6 +112,9 @@ const styles = () => ({
       '&.Mui-focused fieldset': {
         border: '2px solid #747474',
       },
+      "& input::-webkit-search-cancel-button": {
+        display: "none !important",
+      },
     },
   },
 


### PR DESCRIPTION
### Overview

There was an extra clear button within the global search page searchbox input. Hid the built-in one.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CDS-1259](https://tracker.nci.nih.gov/browse/CDS-1259)