### PR TITLE
CDS-1288 Bug: Update data model link to GC

### DIFF
--- a/src/content/dev/aboutPagesContent.yaml
+++ b/src/content/dev/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/dev2/aboutPagesContent.yaml
+++ b/src/content/dev2/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/local/aboutPagesContent.yaml
+++ b/src/content/local/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/perf/aboutPagesContent.yaml
+++ b/src/content/perf/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/prod/aboutPagesContent.yaml
+++ b/src/content/prod/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/qa/aboutPagesContent.yaml
+++ b/src/content/qa/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/qa2/aboutPagesContent.yaml
+++ b/src/content/qa2/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'

--- a/src/content/stage/aboutPagesContent.yaml
+++ b/src/content/stage/aboutPagesContent.yaml
@@ -9,7 +9,7 @@
   title: "Data Model"
   content:
     - paragraph: "The model works with various data types, offering robust yet flexible infrastructure while adhering to FAIR (Findability, Accessibility, Interoperability, and Reuse) data principles. CRDC Data Submission portal continues to evolve to meet the data needs for various NCI-funded programs."
-    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/CDS/latest](https://hub.datacommons.cancer.gov/model-navigator/CDS/latest title: 'Visit the GC-model on CRDC')$$."
+    - paragraph: "All code necessary to use the $$[Bento platform](https://bento-tools.org/#/ title: 'Visit the Bento platform')$$ on which the CRDC Data Submission portal is built is provided in the form of Docker containers. However, the Bento code is also available to the public for research and forking and pull requests. The General Commons (GC) model can be viewed under the CRDC Data Submissions:  $$[https://hub.datacommons.cancer.gov/model-navigator/GC/latest](https://hub.datacommons.cancer.gov/model-navigator/GC/latest title: 'Visit the GC-model on CRDC')$$."
   secondaryZoomImageTitle: "The Core Data Model"
   secondaryZoomImage: 'https://raw.githubusercontent.com/CBIIT/cds-model/main/docs/model-desc/cds-model.svg'
 - page: '/graphql'


### PR DESCRIPTION
### Overview

The DataHub model navigator link was still pointing to CDS instead of GC. This was updated to GC.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CDS-1288](https://tracker.nci.nih.gov/browse/CDS-1288)