### PR TITLE
CDS-1262 updated options to avoid text cutoff for new GC readmepdf

### DIFF
--- a/src/pages/cart/customComponent/readme/components/readmeDialogView.js
+++ b/src/pages/cart/customComponent/readme/components/readmeDialogView.js
@@ -49,12 +49,12 @@ export const downloadMarkdownPdf = async (title, content) => {
   const fileName = createFileName('GC-SELECTED-FILES-CART-README', '');
   /** configure pdf increase pixel of the PDF */
   const options = {
-    margin: [0.5, 0.5, 1.11, 0.5],
+    margin: [0.5, 0.5, 1.0, 0.5],
     filename: fileName,
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: {
       dpi: 192,
-      scale: 4,
+      scale: 5,
       letterRendering: true,
       useCORS: true,
     },


### PR DESCRIPTION
The previous fix strangely stop working didn't work so I tweaked a different setting. Please try to test this functionality locally prior to approval.

[CDS-1262](https://tracker.nci.nih.gov/browse/CDS-1262) 