### PR TITLE
ensure that the Prompt value will always be a strict boolean value

### DIFF
--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -71,7 +71,7 @@ const Layout = ({ classes, isSidebarOpened }) => {
       <HashRouter>
         <>
           <Prompt
-            when={maintenanceMode.enabled && hash === "#/"}
+            when={!!(maintenanceMode.enabled && hash === "#/")}
             message={() => false}
           />
           <Notifactions />


### PR DESCRIPTION
It was found that in the event that maintenanceMode was undefined, prompt would receive the undefined value and defaulted to being enabled

- enabling strict boolean allows it to be falsy when undefined, allowing navigation by default