### PR TITLE
removed extraneous styling, added in top field to adjust alignment

### DIFF
--- a/src/pages/dashTemplate/widget/WidgetStyle.js
+++ b/src/pages/dashTemplate/widget/WidgetStyle.js
@@ -54,9 +54,9 @@ const styles = (theme) => ({
     background: theme.palette.widgetBackground.main,
   },
   floatRight: {
-    float: 'right',
     position: 'absolute',
     right: '80px',
+    top: '4px',
     zIndex: '1',
   },
   floatLeft: {


### PR DESCRIPTION
I had noticed the collapse view button was slipping into the stats bar. I adjusted the top property to make it flush.